### PR TITLE
Allow extension usage rename

### DIFF
--- a/App/Src/Extensions/Usage/ExtensionUsage.Table.al
+++ b/App/Src/Extensions/Usage/ExtensionUsage.Table.al
@@ -53,13 +53,6 @@ table 80004 "C4BC Extension Usage"
         TestRangesPerInstanceUsage()
     end;
 
-    trigger OnRename()
-    var
-        CannotBeRenamedErr: Label 'The record can not be renamed.';
-    begin
-        Error(CannotBeRenamedErr);
-    end;
-
     local procedure TestRangesPerInstanceUsage()
     var
         C4BCExtensionUsage: Record "C4BC Extension Usage";


### PR DESCRIPTION
I don't see a reason why the starting date or other values of the extension usage table couldn't be changed