### PR TITLE
Fix: BC Instance links on Extension Object Line

### DIFF
--- a/App/Src/AssignableRanges/AssignableRangeHeader.Table.al
+++ b/App/Src/AssignableRanges/AssignableRangeHeader.Table.al
@@ -379,11 +379,10 @@ table 80001 "C4BC Assignable Range Header"
         C4BCExtensionObjectLine.SetRange("Object Type", ForObjectType);
         C4BCExtensionObjectLine.SetRange("Assignable Range Code", Rec."Code");
         C4BCExtensionObjectLine.SetRange(ID, Rec."Field Range From", Rec."Field Range To");
-        if Rec."Ranges per BC Instance" then begin
-            // Find extension object lines that are installed on specific business central instance
-            C4BCExtensionObjectLine.SetRange("Bus. Central Instance Filter", ForBusinessCentralInstance);
-            C4BCExtensionObjectLine.SetRange("Bus. Central Instance Linked", true);
-        end;
+
+        // Find extension object lines that are installed on specific business central instance
+        if Rec."Ranges per BC Instance" then
+            C4BCExtensionObjectLine.SetRange("Bus. Central Instance", ForBusinessCentralInstance);
 
         // Find last used object field ID (primary or alternate)
         if C4BCExtensionObjectLine.FindLast() then

--- a/App/Src/AssignableRanges/AssignableRangeHeader.Table.al
+++ b/App/Src/AssignableRanges/AssignableRangeHeader.Table.al
@@ -206,11 +206,10 @@ table 80001 "C4BC Assignable Range Header"
         C4BCExtensionObject.SetAscending("Object ID", true);
         C4BCExtensionObject.SetRange("Object Type", ForObjectType);
         C4BCExtensionObject.SetRange("Assignable Range Code", Rec."Code");
-        if Rec."Ranges per BC Instance" then begin
-            // Find extension lines that are installed on specific business central instance
-            C4BCExtensionObject.SetRange("Bus. Central Instance Filter", ForBusinessCentralInstance);
-            C4BCExtensionObject.SetRange("Bus. Central Instance Linked", true);
-        end;
+
+        // Find extension lines that are installed on specific business central instance
+        if Rec."Ranges per BC Instance" then
+            C4BCExtensionObject.SetRange("Bus. Central Instance", ForBusinessCentralInstance);
 
         // Find last used object ID (primary or alternate)
         if C4BCExtensionObject.FindLast() then
@@ -482,8 +481,7 @@ table 80001 "C4BC Assignable Range Header"
             if ForBusinessCentralInstance = '' then
                 Error(MissingParameterErr, Rec.FieldCaption("Ranges per BC Instance"));
 
-            C4BCExtensionObject.SetRange("Bus. Central Instance Filter", ForBusinessCentralInstance);
-            C4BCExtensionObject.SetRange("Bus. Central Instance Linked", true);
+            C4BCExtensionObject.SetRange("Bus. Central Instance", ForBusinessCentralInstance);
         end;
 
         if not C4BCExtensionObject.IsEmpty then
@@ -508,8 +506,7 @@ table 80001 "C4BC Assignable Range Header"
             if ForBusinessCentralInstance = '' then
                 Error(MissingParameterErr, Rec.FieldCaption("Ranges per BC Instance"));
 
-            C4BCExtensionObject.SetRange("Bus. Central Instance Filter", ForBusinessCentralInstance);
-            C4BCExtensionObject.SetRange("Bus. Central Instance Linked", true);
+            C4BCExtensionObject.SetRange("Bus. Central Instance", ForBusinessCentralInstance);
         end;
 
         if not C4BCExtensionObject.IsEmpty then

--- a/App/Src/Extensions/ExtensionObject.Table.al
+++ b/App/Src/Extensions/ExtensionObject.Table.al
@@ -114,6 +114,9 @@ table 80003 "C4BC Extension Object"
         {
             Caption = 'Business Central Instance Filter';
             FieldClass = FlowFilter;
+
+            ObsoleteState = Pending;
+            ObsoleteReason = 'Replaced by FlowField "Bus. Central Instance"';
         }
         field(102; "Bus. Central Instance Linked"; Boolean)
         {
@@ -121,6 +124,9 @@ table 80003 "C4BC Extension Object"
             Editable = false;
             FieldClass = FlowField;
             CalcFormula = exist("C4BC Extension Header" where("Code" = field("Extension Code"), "BC Instance for Assign. Range" = field("Bus. Central Instance Filter")));
+
+            ObsoleteState = Pending;
+            ObsoleteReason = 'Replaced by FlowField "Bus. Central Instance"';
         }
         field(103; "Alternate Assign. Range Code"; Code[20])
         {
@@ -128,6 +134,13 @@ table 80003 "C4BC Extension Object"
             Editable = false;
             FieldClass = FlowField;
             CalcFormula = lookup("C4BC Extension Header"."Alternate Assign. Range Code" where("Code" = field("Extension Code")));
+        }
+        field(105; "Bus. Central Instance"; Code[20])
+        {
+            Caption = 'Business Central Instance';
+            Editable = false;
+            FieldClass = FlowField;
+            CalcFormula = lookup("C4BC Extension Header"."BC Instance for Assign. Range" where(Code = field("Extension Code")));
         }
         field(150; "Alternate Object ID"; Integer)
         {

--- a/App/Src/Extensions/ExtensionObjectLine.Table.al
+++ b/App/Src/Extensions/ExtensionObjectLine.Table.al
@@ -68,7 +68,7 @@ table 80006 "C4BC Extension Object Line"
             Caption = 'Bus. Central Instance Linked';
             Editable = false;
             FieldClass = FlowField;
-            CalcFormula = exist("C4BC Extension Usage" where("Extension Code" = field("Extension Code"), "Business Central Instance Code" = field("Bus. Central Instance Filter")));
+            CalcFormula = exist("C4BC Extension Header" where("Code" = field("Extension Code"), "BC Instance for Assign. Range" = field("Bus. Central Instance Filter")));
 
             ObsoleteState = Pending;
             ObsoleteReason = 'Replaced by FlowField "Bus. Central Instance"';

--- a/App/Src/Extensions/ExtensionObjectLine.Table.al
+++ b/App/Src/Extensions/ExtensionObjectLine.Table.al
@@ -59,6 +59,9 @@ table 80006 "C4BC Extension Object Line"
         {
             Caption = 'Business Central Instance Filter';
             FieldClass = FlowFilter;
+
+            ObsoleteState = Pending;
+            ObsoleteReason = 'Replaced by FlowField "Bus. Central Instance"';
         }
         field(102; "Bus. Central Instance Linked"; Boolean)
         {
@@ -66,6 +69,9 @@ table 80006 "C4BC Extension Object Line"
             Editable = false;
             FieldClass = FlowField;
             CalcFormula = exist("C4BC Extension Usage" where("Extension Code" = field("Extension Code"), "Business Central Instance Code" = field("Bus. Central Instance Filter")));
+
+            ObsoleteState = Pending;
+            ObsoleteReason = 'Replaced by FlowField "Bus. Central Instance"';
         }
         field(103; "Alternate Assign. Range Code"; Code[20])
         {
@@ -80,6 +86,13 @@ table 80006 "C4BC Extension Object Line"
             Editable = false;
             FieldClass = FlowField;
             CalcFormula = lookup("C4BC Extension Object"."Alternate Object ID" where("Extension Code" = field("Extension Code"), "Object Type" = field("Object Type"), "Object ID" = field("Object ID")));
+        }
+        field(105; "Bus. Central Instance"; Code[20])
+        {
+            Caption = 'Business Central Instance';
+            Editable = false;
+            FieldClass = FlowField;
+            CalcFormula = lookup("C4BC Extension Header"."BC Instance for Assign. Range" where(Code = field("Extension Code")));
         }
         field(150; "Alternate ID"; Integer)
         {


### PR DESCRIPTION
After adding the `"BC Instance for Assign. Range"` to `table 80000 "C4BC Extension Header"` the `GetNewFieldID()` on `table 80001 "C4BC Assignable Range Header"` still looks for assigned instances.

This results in repeating IDs when the extension is not yet assigned to a BC instance, or when it is assigned to multiple instances.

**NOT TESTED**
**NOT TESTED**
**NOT TESTED**
